### PR TITLE
FIX: Release suffix '-alpha1' was missing in Sphinx documentation

### DIFF
--- a/src/build-data/version.txt
+++ b/src/build-data/version.txt
@@ -2,7 +2,7 @@
 release_major = 3
 release_minor = 0
 release_patch = 0
-release_suffix = '-alpha0'
+release_suffix = '-alpha1'
 release_so_abi_rev = 0
 
 # These are set by the distribution script

--- a/src/configs/sphinx/conf.py
+++ b/src/configs/sphinx/conf.py
@@ -44,6 +44,7 @@ version_info = parse_version_file('../../build-data/version.txt')
 version_major = version_info['release_major']
 version_minor = version_info['release_minor']
 version_patch = version_info['release_patch']
+version_suffix = version_info['release_suffix']
 
 is_website_build = check_for_tag('website')
 
@@ -58,10 +59,10 @@ source_encoding = 'utf-8-sig'
 master_doc = 'contents'
 
 project = u'botan'
-copyright = u'2000-2017, The Botan Authors'
+copyright = u'2000-2022, The Botan Authors'
 
 version = '%d.%d' % (version_major, version_minor)
-release = '%d.%d.%d' % (version_major, version_minor, version_patch)
+release = '%d.%d.%d%s' % (version_major, version_minor, version_patch, version_suffix)
 
 #today = ''
 today_fmt = '%Y-%m-%d'


### PR DESCRIPTION
![Screenshot 2022-07-29 185658](https://user-images.githubusercontent.com/1562139/181808098-7c530c57-e0e8-49d8-a138-183c040d9dbf.png)
