### PR TITLE
Use JUnit reports to generate a Test Report Document + Generate Source Tarball

### DIFF
--- a/.github/workflows/bsi.yml
+++ b/.github/workflows/bsi.yml
@@ -91,9 +91,46 @@ jobs:
       - name: Build and Test Botan
         run: python3 ./src/scripts/ci_build.py --with-bsi-policy --cc='${{ matrix.platform.compiler }}' --make-tool='${{ matrix.platform.make_tool }}' --test-results-dir=junit_reports ${{ matrix.target }}
 
-      - name: Archive Artifacts
+      - name: Store JUnit Report
         uses: actions/upload-artifact@v3
+        if: always()
         with:
           name: junit
           path: junit_reports/*.xml
+          if-no-files-found: error
+
+  test_report:
+    name: "Generate Test Report"
+    needs: bsi_tests
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Shorten the Git SHA
+        id: vars
+        run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Setup Build Agent
+        uses: ./.github/actions/setup-build-agent
+        with:
+          target: test-report
+
+      - name: Fetch JUnit Reports
+        uses: actions/download-artifact@v3
+        with:
+          name: junit
+          path: junit_reports
+
+      - name: Generate Test Report
+        run: |
+             python3 ./src/scripts/bsi_test_report.py --preamble doc/report_assets/testreport_preamble.rst --format=rst junit_reports test-report-${{ steps.vars.outputs.short_sha }}.rst
+             python3 ./src/scripts/bsi_test_report.py --preamble doc/report_assets/testreport_preamble.rst --format=pdf junit_reports test-report-${{ steps.vars.outputs.short_sha }}.pdf
+
+      - name: Store Test Report
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: Test Report
+          path: test-report-*.*
           if-no-files-found: error

--- a/.github/workflows/bsi.yml
+++ b/.github/workflows/bsi.yml
@@ -143,8 +143,8 @@ jobs:
 
       - name: Generate Test Report
         run: |
-             python3 ./src/scripts/bsi_test_report.py --preamble doc/report_assets/testreport_preamble.rst --format=rst junit_reports test-report-${{ steps.vars.outputs.short_sha }}.rst
-             python3 ./src/scripts/bsi_test_report.py --preamble doc/report_assets/testreport_preamble.rst --format=pdf junit_reports test-report-${{ steps.vars.outputs.short_sha }}.pdf
+             python3 ./src/scripts/bsi_test_report.py --preamble doc/report_assets/testreport_preamble.rst --git-refname ${{ github.ref_name }} --git-refsha ${{ github.sha }} --format=rst junit_reports test-report-${{ steps.vars.outputs.short_sha }}.rst
+             python3 ./src/scripts/bsi_test_report.py --preamble doc/report_assets/testreport_preamble.rst --git-refname ${{ github.ref_name }} --git-refsha ${{ github.sha }} --format=pdf junit_reports test-report-${{ steps.vars.outputs.short_sha }}.pdf
 
       - name: Store Test Report
         uses: actions/upload-artifact@v3

--- a/.github/workflows/bsi.yml
+++ b/.github/workflows/bsi.yml
@@ -89,4 +89,11 @@ jobs:
           cache-key: bsi-${{ matrix.platform.host_os }}-${{ matrix.platform.compiler }}-${{ matrix.target }}
 
       - name: Build and Test Botan
-        run: python3 ./src/scripts/ci_build.py --with-bsi-policy --cc='${{ matrix.platform.compiler }}' --make-tool='${{ matrix.platform.make_tool }}' ${{ matrix.target }}
+        run: python3 ./src/scripts/ci_build.py --with-bsi-policy --cc='${{ matrix.platform.compiler }}' --make-tool='${{ matrix.platform.make_tool }}' --test-results-dir=junit_reports ${{ matrix.target }}
+
+      - name: Archive Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: junit
+          path: junit_reports/*.xml
+          if-no-files-found: error

--- a/.github/workflows/bsi.yml
+++ b/.github/workflows/bsi.yml
@@ -61,6 +61,25 @@ jobs:
           path: ${{ matrix.artifacts }}
         if: ${{ matrix.artifacts != '' }}
 
+  tarball:
+    name: "Source Tarball"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Shorten the Git SHA
+        id: vars
+        run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Generate Tarball
+        run: tar -czf botan-${{ steps.vars.outputs.short_sha }}.tar.gz .github doc src configure.py license.txt news.rst readme.rst
+
+      - name: Archive Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: "Botan Source Tarball"
+          path: botan-*.tar.gz
+
   bsi_tests:
     name: "BSI Build Policy Tests"
     strategy:

--- a/configure.py
+++ b/configure.py
@@ -2104,6 +2104,7 @@ def create_template_vars(source_paths, build_paths, options, modules, cc, arch, 
                                               suffix=options.library_suffix),
 
         'command_line': configure_command_line(),
+        'command_line_escaped': configure_command_line().replace("\\", "\\\\").replace("\"", "\\\""),
         'local_config': read_textfile(options.local_config),
 
         'program_suffix': program_suffix,
@@ -3273,6 +3274,7 @@ def do_io_for_build(cc, arch, osinfo, using_mods, info_modules, build_paths, sou
         return os.path.join(build_paths.doc_module_info, p)
 
     write_template(in_build_dir('build.h'), in_build_data('buildh.in'))
+    write_template(in_build_dir('build_info.h'), in_build_data('buildinfoh.in'))
     write_template(in_build_dir('botan.doxy'), in_build_data('botan.doxy.in'))
 
     if 'botan_pkgconfig' in template_vars:
@@ -3489,6 +3491,7 @@ def main(argv):
 
     build_paths = BuildPaths(source_paths, options, using_mods)
     build_paths.public_headers.append(os.path.join(build_paths.build_dir, 'build.h'))
+    build_paths.internal_headers.append(os.path.join(build_paths.build_dir, 'build_info.h'))
 
     template_vars = create_template_vars(source_paths, build_paths, options, using_mods, cc, arch, osinfo)
 

--- a/doc/report_assets/testreport_preamble.rst
+++ b/doc/report_assets/testreport_preamble.rst
@@ -2,6 +2,22 @@
 Botan Test Report
 =================
 
+.. list-table::
+   :header-rows: 0
+
+   * - Botan Version
+     - %{botan_version}
+   * - Git Revision
+     - %{botan_git_sha}
+   * - Git Reference
+     - %{botan_git_ref}
+   * - Generation Date
+     - %{date_today}
+
+.. raw:: latex
+
+   \pagebreak
+
 Preface
 =======
 

--- a/doc/report_assets/testreport_preamble.rst
+++ b/doc/report_assets/testreport_preamble.rst
@@ -1,0 +1,88 @@
+=================
+Botan Test Report
+=================
+
+Preface
+=======
+
+**Summary**
+
+The objective of this project is the secure implementation of a universal crypto
+library which contains all common cryptographic primitives that are necessary for
+the wide use of cryptographic operations. These include symmetric and asymmetric
+encryption and signature methods, PRFs, hash functions and RNGs. Additionally,
+security standards such as X.509 and SSL/TLS have to be supported. The library will
+be provided to manufacturers of VS-NfD products which will help the Federal Office
+for Information Security (BSI) to evaluate these products.
+
+This document reports the test results of the Botan test suite.
+
+**Authors**
+
+| Daniel Neus (DN)
+| René Fischer (RK)
+| René Meusel (RM)
+
+**Copyright**
+
+This work is protected by copyright law. Every application outside of
+copyright law without explicit permission by the
+Federal Office for Information Security (BSI) is forbidden and will be prosecuted.
+This holds especially for the reproduction, translation, microfilming and
+storing and processing in electronic systems.
+
+.. raw:: latex
+
+   \pagebreak
+
+Changelog
+=========
+
+.. table::
+   :class: longtable
+
+   +---------+----------+---------------------------------------------+------------+
+   | Version | Authors  | Comment                                     | Date       |
+   +=========+==========+=============================================+============+
+   | 1.0.0   | DN, RK   | Initial version                             | 2016-11-11 |
+   +---------+----------+---------------------------------------------+------------+
+   | 1.1.0   | RK       | Update to Botan 2.0.0                       | 2017-01-09 |
+   +---------+----------+---------------------------------------------+------------+
+   | 1.2.0   | DN       | Update to Botan 2.0.1-RSCS1                 | 2017-03-06 |
+   +---------+----------+---------------------------------------------+------------+
+   | 1.3.0   | RK       | Update to Botan 2.4.0                       | 2018-05-07 |
+   +---------+----------+---------------------------------------------+------------+
+   | 1.3.1   | RK       | Update to latest Botan 2.4.0-RSCS1          | 2018-05-07 |
+   +---------+----------+---------------------------------------------+------------+
+   | 1.4.0   | RK       | Update to Botan 2.14.0-RSCS1                | 2020-06-24 |
+   +---------+----------+---------------------------------------------+------------+
+   | 1.5.0   | RM       | Update to Botan 3.0.0-alpha1-BSI1           | 2022-11-21 |
+   +---------+----------+---------------------------------------------+------------+
+   | 2.0.0   | RM       | | Switch to automatically generated test    | -          |
+   |         |          | | report. End of the changelog.             |            |
+   +---------+----------+---------------------------------------------+------------+
+
+.. raw:: latex
+
+   \pagebreak
+
+Test Report
+===========
+
+The following report lists the test results for the Botan test suite.
+The following information is given for each test run:
+
+ * Information about the test environment
+    * Botan configuration
+    * Date and time of execution
+    * Operating system
+    * Compiler and compiler version
+    * Target architecture
+ * Number of tests executed
+    * Of these, the number of tests executed successfully
+    * Of these, the number of failed tests
+ * A list of failed tests and the reason for each test failure
+
+.. raw:: latex
+
+   \pagebreak

--- a/src/build-data/buildinfoh.in
+++ b/src/build-data/buildinfoh.in
@@ -1,0 +1,20 @@
+#ifndef BOTAN_BUILD_INFO_H_
+#define BOTAN_BUILD_INFO_H_
+
+/**
+* @file  build_info.h
+* @brief Build information for Botan %{version}
+*
+* Automatically generated from
+* '%{command_line}'
+*
+* Target
+*  - Compiler: %{cxx} %{cxx_abi_flags} %{cc_lang_flags} %{cc_compile_flags}
+*  - Arch: %{arch}
+*  - OS: %{os}
+*/
+
+#define BOTAN_CONFIGURE_COMMAND "%{command_line_escaped}"
+#define BOTAN_BUILD_ARCHITECTURE "%{arch}"
+
+#endif

--- a/src/scripts/bsi_test_report.py
+++ b/src/scripts/bsi_test_report.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+
+import sys
+import os
+import glob
+import argparse
+from itertools import chain
+from functools import reduce
+from datetime import datetime
+
+import junitparser
+
+
+class Testsuites(junitparser.JUnitXml):
+    ''' We override the libary's root element to support
+        properties in the 'Testsuites' XML root.'''
+
+    def properties(self):
+        """Iterates through all properties."""
+        props = self.child(junitparser.Properties)
+        if props is None:
+            return
+        for prop in props:
+            yield prop
+
+    def get_property(self, key):
+        for p in self.properties():
+            if p.name == key:
+                return p.value
+        raise LookupError("property did not exist")
+
+    @property
+    def platform(self):
+        known_platforms = {'linux': 'Linux', 'osx': 'macOS', 'windows': 'Windows', 'freebsd': 'FreeBSD'}
+        osstr = self.get_property("os")
+        return known_platforms[osstr] if osstr in known_platforms else 'Unknown System'
+
+    @property
+    def os(self):
+        return self.get_property('os_name')
+
+    @property
+    def os_version(self):
+        return self.get_property('os_version')
+
+    @property
+    def compiler(self):
+        return self.get_property('compiler')
+
+    @property
+    def compiler_version(self):
+        return self.get_property('compiler_version')
+
+    @property
+    def test_command(self):
+        return self.get_property('command')
+
+    @property
+    def configure_command(self):
+        return self.get_property('build_configuration')
+
+    @property
+    def architecture(self):
+        return self.get_property('architecture')
+
+    @property
+    def build_target(self):
+        return self.get_property('ci_target')
+
+    @property
+    def timestamp(self):
+        # Timestamp is in fully qualified ISO format (potentially with) time zone offset.
+        # Python supports this only from 3.11
+        #
+        # See: https://docs.python.org/3/library/datetime.html#datetime.date.fromisoformat
+        if sys.version_info >= (3, 11):
+            return datetime.fromisoformat(self.get_property('timestamp'))
+        elif sys.version_info >= (3, 7):
+            return datetime.fromisoformat(self.get_property('timestamp')[:10])
+        else:
+            raise RuntimeError("Python is too old to read ISO timestamp")
+
+    @property
+    def assertions(self):
+        asserts = map(lambda x: int(
+            x._elem.attrib['assertions']), chain.from_iterable(self))
+        return sum(asserts)
+
+    def _format_command(self, command):
+        cmd = command.replace('\\', '/').split(' --')
+
+        def irrelevant_params(param):
+            filtered_params = ['prefix', 'report-properties',
+                               'with-external-includedir', 'test-results-dir']
+            for p in filtered_params:
+                if param.startswith(p):
+                    return False
+            return True
+        return '\n --'.join(filter(irrelevant_params, cmd))
+
+    def _escape_multiline_string(self, content, indentation_depth=0):
+        if '\n' not in content:
+            return content
+        first_line = True
+        out = []
+        for line in content.split('\n'):
+            if first_line:
+                out.append('| %s' % line)
+                first_line = False
+            else:
+                out.append('%s| %s' % (' ' * indentation_depth, line))
+        return '\n'.join(out)
+
+    def render(self):
+        rst = '\n'.join([
+            '.. list-table:: %s %s %s' % (self.os, self.compiler, self.build_target),
+            '  :widths: 20 80',
+            '  :header-rows: 0'])
+        rst += '\n\n'
+
+        contents = {'Build Name': self.build_target,
+                    'Build Config': self._format_command(self.configure_command),
+                    'Test Execution': self._format_command(self.test_command),
+                    'Date': self.timestamp.date(),
+                    'System': self.os,
+                    'OS Version': self.os_version,
+                    'Compiler': self.compiler + ' ' + self.compiler_version,
+                    'Architecture': self.architecture,
+                    'Tests Executed': '%d (%d assertions)' % (self.tests, self.assertions),
+                    'Tests Passed': self.tests - self.failures - self.skipped,
+                    'Tests Failed': self.failures,
+                    'Tests Skipped': self.skipped}
+
+        for title, content in contents.items():
+            str_content = str(content)
+            rst += '  * - %s\n    - %s\n' % (
+                title, self._escape_multiline_string(str_content, 6))
+        return rst
+
+
+class Report:
+    def __init__(self, report_files, preamble_file=None):
+        if preamble_file:
+            with open(preamble_file) as f:
+                self.preamble = f.read()
+        else:
+            self.preamble = self._headline("Botan Test Report")
+
+        self.reports = [Testsuites.fromfile(report) for report in report_files]
+        self.reports.sort(key=lambda x: x.platform +
+                          x.os_version, reverse=True)
+
+    def _headline(self, content, level=1):
+        if level in [1, 2]:
+            line = '='
+        elif level == 3:
+            line = '-'
+        else:
+            raise ValueError("Headline level 1-3 are supported only")
+
+        line = line * len(content)
+        if level == 1:
+            return '\n'.join([line, content, line, ''])
+        else:
+            return '\n'.join([content, line, ''])
+
+    def _pagebreak(self):
+        return '\n'.join(['.. raw:: latex',
+                          '',
+                          '   \pagebreak',
+                          ''])
+
+    def _render_rst(self):
+        current_chapter = ""
+        out = [self.preamble]
+        for report in self.reports:
+            if current_chapter != report.platform:
+                current_chapter = report.platform
+                out.append(self._headline(current_chapter, level=3))
+            out.append(report.render())
+            out.append(self._pagebreak())
+        return '\n\n'.join(out)
+
+    def render(self, outfile, format):
+        if format == 'pdf':
+            from pypandoc import convert_text
+            convert_text(self._render_rst().encode('utf-8'), 'pdf',
+                         format='rst', outputfile=outfile)
+        elif format == 'rst':
+            with open(outfile, 'w+') as f:
+                f.write(self._render_rst())
+        else:
+            raise ValueError("unknown output format: " + format)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog='BSI Test Result Generator',
+        description='This takes a bunch of JUnit test results and generates a summary document from them.')
+
+    parser.add_argument('reportsdir',
+                        help='Directory where junit reports are stored. All *.xml files will be picked up.')
+    parser.add_argument('reportfile',
+                        help='Output file to be generated')
+    parser.add_argument('--format', choices=['pdf', 'rst'], default='rst',
+                        help='Output format of the report file')
+    parser.add_argument('--preamble', default=None,
+                        help='Input file containing reStructuredText that should be added before the generated report')
+
+    args = parser.parse_args()
+
+    if not os.path.isdir(args.reportsdir):
+        raise Exception("Cannot read junit files from given reports directory")
+ 
+    report_files = glob.glob(os.path.join(args.reportsdir, "*.xml"))
+    if not report_files:
+        raise Exception("Did not find any junit reports")
+
+    report = Report(report_files, args.preamble)
+    report.render(args.reportfile, format=args.format)
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/src/scripts/ci/setup_gh_actions.sh
+++ b/src/scripts/ci/setup_gh_actions.sh
@@ -92,6 +92,10 @@ if type -p "apt-get"; then
         if [ "$TARGET" = "pdf_docs" ]; then
             sudo apt-get -qq install latexmk texlive-latex-extra
         fi
+
+    elif [ "$TARGET" = "test-report" ]; then
+        sudo apt-get -qq install pandoc python3-pypandoc texlive-latex-extra python3-junitparser
+
     fi
 else
     export HOMEBREW_NO_AUTO_UPDATE=1

--- a/src/tests/main.cpp
+++ b/src/tests/main.cpp
@@ -93,6 +93,7 @@ int main(int argc, char* argv[])
 #endif
 
       const Botan_Tests::Test_Options opts(
+         std::vector<std::string>(argv, argv + argc),
          parser.get_arg_list("suites"),
          parser.get_arg_list("skip-tests"),
          parser.get_arg_or("data-dir", "src/tests/data"),

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -61,7 +61,8 @@ class Test_Options
    public:
       Test_Options() = default;
 
-      Test_Options(const std::vector<std::string>& requested_tests,
+      Test_Options(const std::vector<std::string>& command,
+                   const std::vector<std::string>& requested_tests,
                    const std::vector<std::string>& skip_tests,
                    const std::string& data_dir,
                    const std::string& pkcs11_lib,
@@ -77,6 +78,7 @@ class Test_Options
                    bool run_long_tests,
                    bool run_memory_intensive_tests,
                    bool abort_on_first_fail) :
+         m_command(command),
          m_requested_tests(requested_tests),
          m_skip_tests(skip_tests.begin(), skip_tests.end()),
          m_data_dir(data_dir),
@@ -95,6 +97,8 @@ class Test_Options
          m_abort_on_first_fail(abort_on_first_fail)
          {
          }
+
+      const std::vector<std::string>& invoked_command() const { return m_command; }
 
       const std::vector<std::string>& requested_tests() const
          { return m_requested_tests; }
@@ -131,6 +135,7 @@ class Test_Options
       bool verbose() const { return m_verbose; }
 
    private:
+      std::vector<std::string> m_command;
       std::vector<std::string> m_requested_tests;
       std::set<std::string> m_skip_tests;
       std::string m_data_dir;


### PR DESCRIPTION
### Description

This uses the JUnit reports generated in https://github.com/randombit/botan/pull/3028 and released as part of Botan 3.0 and transforms them into a summary report usable for a BSI deliverable.

Furthermore, this adds a CI job to roll a tarball of the sources.

![image](https://user-images.githubusercontent.com/1562139/203729171-b7206e05-4eb1-4764-858a-1162591676bb.png)


### State of this PR

This is somewhat a proof-of-concept to generate BSI deliverables. Also: For maintainability it might be better to collect these document generation scripts in a dedicated repository. This remains to be seen.